### PR TITLE
Update conway to follow the newer hy syntax

### DIFF
--- a/conway.hy
+++ b/conway.hy
@@ -2,26 +2,26 @@
 
 (def *world* (grid.Torus 10 10))
 
-(defun set! (world x y value)
+(defn set! [world x y value]
   (setv (get world (, x y)) value))
 
-(defun get! (world x y)
+(defn get! [world x y]
   (get *world* (, x y)))
 
 
-(defun neighbours (world x y)
+(defn neighbours [world x y]
   (sum (list-comp
         (get! world (+ x dx) (+ y dy))
          (dx [-1 0 1]
           dy [-1 0 1])
         (!= (, (+ x dx) (+ y dy)) (, x y)))))
 
-(defun step (world)
-  (let ((new-world (.copy grid.Torus world)))
-    (for (x (range new-world.width))
-         (for (y (range new-world.height))
-              (let ((cell (get! new-world x y))
-                    (ns (neighbours world x y)))
+(defn step [world]
+  (let [[new-world (.copy grid.Torus world)]]
+    (for [x (range new-world.width)]
+      (for [y (range new-world.height)]
+	(let [[cell (get! new-world x y)]
+	      [ns (neighbours world x y)]]
                 (if (= cell 1)
                     (cond [(< ns 2) (set! new-world x y 0)]
                           [(or (= ns 2) (= ns 3)) (set! new-world x y 1)]
@@ -40,7 +40,7 @@
 (set! *world* 5 4 1)
 
 ;; Cycle through once...
-(for (_ (range 5))
+(for [_ (range 5)]
      (.pprint grid.Torus *world*)
      (setv *world* (step *world*))
      (print))


### PR DESCRIPTION
- Fix cases for function definitions where sexp forms were used instead
  of vector forms
- Fix `let` and `for` forms
